### PR TITLE
Move 'The Hope of Elantris' to after 'Elantris' in reading order

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -264,7 +264,7 @@
                             "publication": "April 2005",
                             "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/298/#e9926'>Occurs long before Mistborn Era 1, but not thousands of years before.</a>",
                             "sorting": {
-				"order": 1.31,
+				"order": 1.3,
                                 "publication": 2005.04,
                                 "chronology": 3.1
                             },
@@ -331,7 +331,7 @@
                             "publication": "January 2006",
                             "chronology": "Shortly after the events of Elantris, and concerning events during the end of that book.",
                             "sorting": {
-				"order": 1.3,
+				"order": 1.31,
                                 "publication": 2006.01,
                                 "chronology": 3.11
                             },


### PR DESCRIPTION
I'm following this reading order as I'm reading through Cosmere for the first time.
Today I was about to start reading _The Hope of Elantris_ but noticed the spoiler warning at the start. Other sources seem to advice reading it afterwards _Elantris_.

According to [Sanderson himself](https://www.brandonsanderson.com/the-hope-of-elantris/):

> Either way, if you haven’t read the novel Elantris, this contains major spoilers. Might I suggest reading the book first? This story won’t work at all for you if you haven’t.

And the [Reddit Cosmere Wiki](https://www.reddit.com/r/Cosmere/wiki/order)

> Read The Hope of Elantris any time after Elantris.