### PR TITLE
Minor Changes on a typo + SA5

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -53,7 +53,7 @@
                 {
                     "id": "forthcoming",
                     "description": "Forthcoming",
-                    "details": "Forthcoming works which a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
+                    "details": "Forthcoming works with a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
                     "color": "#888888"
                 },
                 {

--- a/public/data.json
+++ b/public/data.json
@@ -1224,7 +1224,7 @@
 				"publication": 2023.11,
                                 "chronology": 7.05
                             },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
+                            "categories": [ "stormlight", "plan", "forthcoming", "novel" ]
                         },
                         {
                             "id": "lopen",


### PR DESCRIPTION
I found a typo on the forthcoming section, which I fixed in the json, and also because SA5 is being worked on I changed its tag from "plan" to "forthcoming"